### PR TITLE
Add public path option for assets

### DIFF
--- a/example/tradie.config.js
+++ b/example/tradie.config.js
@@ -10,6 +10,10 @@ module.exports = {
     extensions: ['.js', '.jsx']
   },
 
+  asset: {
+    publicPath: 'public/'
+  },
+
   plugins: [
     copy({files: ['index.html']}),
     serve(),

--- a/src/api/webpack/util/configureAssets.js
+++ b/src/api/webpack/util/configureAssets.js
@@ -1,7 +1,7 @@
 import extensionsToRegex from 'ext-to-regex';
 
 export default function configureAssets(options, webpackConfig) {
-  const {asset: {extensions, outputFilename}} = options;
+  const {asset: {extensions, outputFilename, publicPath}} = options;
 
   //configure the asset filename
   let filename = 'files/[hash].[ext]'; //optimize ? '[path][name].[hash].js' :
@@ -14,7 +14,10 @@ export default function configureAssets(options, webpackConfig) {
     test: extensionsToRegex(extensions),
     use: {
       loader: 'file-loader',
-      options: {name: filename}
+      options: {
+        name: filename,
+        publicPath: publicPath
+      }
     }
   });
 


### PR DESCRIPTION
We ran into an issue with using styled components for our icon font in arhi-web where the path to the fonts was not including the 'public' added in the solution. Adding the option to specify a `publicPath` allows us to get the correct path to the fonts 👍 